### PR TITLE
feat(demo): add interactive demo page with guided onboarding tour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "debounce": "^2.0.0",
         "dotenv": "^16.4.1",
         "downshift": "^8.3.1",
+        "driver.js": "^1.4.0",
         "firebase": "^10.7.2",
         "firebaseui": "^6.1.0",
         "flowbite": "^2.2.1",
@@ -4241,6 +4242,11 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew=="
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "debounce": "^2.0.0",
     "dotenv": "^16.4.1",
     "downshift": "^8.3.1",
+    "driver.js": "^1.4.0",
     "firebase": "^10.7.2",
     "firebaseui": "^6.1.0",
     "flowbite": "^2.2.1",

--- a/src/app/components/guarded-page/index.jsx
+++ b/src/app/components/guarded-page/index.jsx
@@ -8,23 +8,25 @@ const GuardedPage = ({ children }) => {
   const { user, loading } = useAuth();
   const router = useRouter();
 
+  const isDemoUser = user?.email === "ailettedemo@gmail.com";
+
   useEffect(() => {
     if (!loading && !user) {
-      console.log("User not authenticated, redirecting to login.");
       router.push("/login");
+    } else if (!loading && isDemoUser) {
+      router.replace("/demo");
     }
-  }, [user, loading, router]);
+  }, [user, loading, router, isDemoUser]);
 
   if (loading) {
-    return (
-      <LoadingScreen />
-      // <div className="min-h-screen flex items-center justify-center">
-      //   <div className="animate-pulse">Loading...</div>
-      // </div>
-    );
+    return <LoadingScreen />;
   }
 
-  return user ? children : null;
+  if (!user || isDemoUser) {
+    return null;
+  }
+
+  return children;
 };
 
 export default GuardedPage;

--- a/src/app/components/header/index.jsx
+++ b/src/app/components/header/index.jsx
@@ -16,31 +16,28 @@ import "./header-styles.css";
  * @param {function} setIsSidebarOpen - Function to set the state of the sidebar.
  * @returns {JSX.Element} The rendered header component.
  */
-const Header = ({ isSidebarOpen, setIsSidebarOpen }) => {
+const Header = ({ isSidebarOpen, setIsSidebarOpen, disableSidebar = false }) => {
   const { user } = useAuth();
 
   return (
     <>
       {/* Spacer div with margin for the floating header */}
       <div className="h-18 px-2 pb-2 pt-3 bg-[#2d2d2d] relative">
-        <header 
+        <header
           className="h-14 rounded-md relative mx-auto shadow-md"
           style={{
             background: 'linear-gradient(to bottom, #1a1a1a 0%, black 100%)'
           }}
         >
-          {/* Gradient fade at bottom */}
-          {/* <div className="absolute bottom-0 left-0 right-0 h-4 bg-gradient-to-b from-black to-transparent" /> */}
-
           {/* Header content */}
           <div className="relative flex items-center h-full px-4 z-[100]">
             {/* Left: Menu Button */}
             <button
-              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-              className="pancake-button p-2 rounded-lg hover:bg-white/5 transition-colors"
+              onClick={() => !disableSidebar && setIsSidebarOpen(!isSidebarOpen)}
+              className={`pancake-button p-2 rounded-lg transition-colors ${disableSidebar ? 'opacity-30 cursor-default' : 'hover:bg-white/5'}`}
               aria-label="Toggle menu"
             >
-              {isSidebarOpen ? (
+              {isSidebarOpen && !disableSidebar ? (
                 <XMarkIcon className="h-5 w-5 text-gray-400" />
               ) : (
                 <Bars3Icon className="h-5 w-5 text-gray-400" />

--- a/src/app/components/hg-layout/index.jsx
+++ b/src/app/components/hg-layout/index.jsx
@@ -29,7 +29,7 @@ import { set } from "date-fns";
  * @param {React.ReactNode} props.children - The child components to be rendered within the layout.
  * @returns {JSX.Element} The rendered PageLayout component.
  */
-const PageLayout = ({ header, footer, children }) => {
+const PageLayout = ({ header, footer, children, disableSidebar = false }) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [pickTitle, setPickTitle] = useState(null);
   const [leaguePicksTitle, setLeaguePicksTitle] = useState(null);
@@ -42,22 +42,22 @@ const PageLayout = ({ header, footer, children }) => {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
           {/* Left Column */}
           <div className="flex flex-col gap-2">
-            <WidgetContainer title={pickTitle}>
+            <WidgetContainer id="widget-pick" title={pickTitle}>
               <Pick setTitle={setPickTitle} />
             </WidgetContainer>
 
-            <WidgetContainer title="League Scoreboard" defaultExpanded={false}>
+            <WidgetContainer id="widget-leaderboard" title="League Scoreboard" defaultExpanded={false}>
               <Leaderboard />
             </WidgetContainer>
           </div>
 
           {/* Right Column */}
           <div className="flex flex-col gap-2">
-            <WidgetContainer title="My Pick History" defaultExpanded={false}>
+            <WidgetContainer id="widget-pick-history" title="My Pick History" defaultExpanded={false}>
               <PickHistory />
             </WidgetContainer>
 
-            <WidgetContainer title={leaguePicksTitle} defaultExpanded={false}>
+            <WidgetContainer id="widget-league-picks" title={leaguePicksTitle} defaultExpanded={false}>
               <LeaguePicks setTitle={setLeaguePicksTitle} />
             </WidgetContainer>
           </div>
@@ -80,13 +80,14 @@ const PageLayout = ({ header, footer, children }) => {
         <Header
           className="bg-gray-200 px-2 w-full z-10"
           isSidebarOpen={isSidebarOpen}
-          setIsSidebarOpen={setIsSidebarOpen}
+          setIsSidebarOpen={disableSidebar ? undefined : setIsSidebarOpen}
+          disableSidebar={disableSidebar}
         >
           {header}
         </Header>
 
         <div className="flex-grow flex relative body-container">
-          <Sidebar isOpen={isSidebarOpen} />
+          {!disableSidebar && <Sidebar isOpen={isSidebarOpen} />}
 
           {/* Main content */}
           <div className="flex-grow overflow-x-hidden">

--- a/src/app/components/pick-history-modal/index.jsx
+++ b/src/app/components/pick-history-modal/index.jsx
@@ -88,7 +88,7 @@ const PickHistoryModal = ({ isOpen, onClose, memberId, memberName }) => {
             leaveFrom="opacity-100 scale-100"
             leaveTo="opacity-0 scale-95"
           >
-            <Dialog.Panel className="w-full max-w-2xl transform rounded-xl bg-[#1a1a1a] shadow-2xl transition-all relative">
+            <Dialog.Panel id="pick-history-modal" className="w-full max-w-2xl transform rounded-xl bg-[#1a1a1a] shadow-2xl transition-all relative">
               <button
                 onClick={handleClose}
                 className="absolute top-4 right-4 p-1 rounded-full hover:bg-white/5 transition-colors duration-200"

--- a/src/app/components/sidebar/index.jsx
+++ b/src/app/components/sidebar/index.jsx
@@ -24,15 +24,6 @@ const menuItems = [
       </svg>
     )
   },
-  { 
-    label: 'Legacy Form',
-    href: 'https://docs.google.com/forms/d/e/1FAIpQLScqFE9p85yilbw00gtHi2-aKgXakE8GYg-W2borVuPaXvGapQ/viewform',
-    icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-        <path d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" />
-      </svg>
-    )
-  }
 ];
 
 const Sidebar = ({ isOpen }) => {

--- a/src/app/components/widget-container/index.jsx
+++ b/src/app/components/widget-container/index.jsx
@@ -2,12 +2,12 @@ import React, { useState } from "react";
 import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import { motion } from "framer-motion";
 
-const WidgetContainer = ({ title, children, defaultExpanded = true }) => {
+const WidgetContainer = ({ id, title, children, defaultExpanded = true }) => {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const [showBorder, setShowBorder] = useState(defaultExpanded);
 
   return (
-    <div className="
+    <div id={id} className="
       rounded-md bg-[#1a1a1a]
       border border-white/10
       backdrop-blur-sm

--- a/src/app/demo/page.js
+++ b/src/app/demo/page.js
@@ -1,0 +1,278 @@
+"use client";
+import React, { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { getAuth, signInWithEmailAndPassword, signOut, setPersistence, browserSessionPersistence } from "firebase/auth";
+import { driver } from "driver.js";
+import "driver.js/dist/driver.css";
+import { app } from "../../config/firebaseConfig";
+import { useAuth } from "../components/auth-provider";
+import PageLayout from "../components/hg-layout";
+import LoadingScreen from "../components/loading-screen";
+import { Logo } from "../components/logo";
+
+const DEMO_EMAIL = "ailettedemo@gmail.com";
+const DEMO_PASSWORD = process.env.NEXT_PUBLIC_DEMO_PASSWORD;
+
+const WIDGET_IDS = ["#widget-pick", "#widget-leaderboard", "#widget-pick-history", "#widget-league-picks"];
+
+/**
+ * Expands a widget if collapsed. On mobile, collapses all other widgets first.
+ */
+const expandWidget = (id) => {
+  const isMobile = window.innerWidth < 1024;
+
+  if (isMobile) {
+    WIDGET_IDS.forEach((wid) => {
+      if (wid === id) return;
+      const widget = document.querySelector(wid);
+      if (!widget) return;
+      const content = widget.querySelector('[style*="overflow: hidden"]');
+      if (content && content.offsetHeight > 0) {
+        const btn = widget.querySelector('button[aria-label="Toggle widget"]');
+        if (btn) btn.click();
+      }
+    });
+  }
+
+  const widget = document.querySelector(id);
+  if (!widget) return;
+  const content = widget.querySelector('[style*="overflow: hidden"]');
+  if (content && content.offsetHeight === 0) {
+    const btn = widget.querySelector('button[aria-label="Toggle widget"]');
+    if (btn) btn.click();
+  }
+};
+
+const LEADERBOARD_STEP_INDEX = 2;
+const MODAL_STEP_INDEX = 3;
+
+const TOUR_STEPS = [
+  {
+    popover: {
+      title: "Welcome to pick.golf!",
+      description: "Every week, you pick one golfer to represent you in that week's PGA tournament. Let's walk through the dashboard.",
+    },
+  },
+  {
+    element: "#widget-pick",
+    popover: {
+      title: "Your Pick",
+      description: "This is where you make your weekly pick. Choose any golfer in the field before the tournament starts. Hit 'Change Pick' to try it out!",
+    },
+    onHighlightStarted: () => expandWidget("#widget-pick"),
+  },
+  {
+    element: "#widget-leaderboard",
+    popover: {
+      title: "League Scoreboard",
+      description: "See how you stack up against your league. Points are based on how your golfer finishes each week. Click any member's name to see their pick history — let's try it.",
+    },
+    onHighlightStarted: () => expandWidget("#widget-leaderboard"),
+  },
+  {
+    element: "#pick-history-modal",
+    popover: {
+      title: "Pick History Modal",
+      description: "Here's a member's full season — toggle between table and graph view. Every pick, result, and point total at a glance.",
+    },
+  },
+  {
+    element: "#widget-pick-history",
+    popover: {
+      title: "Pick History",
+      description: "Your full season at a glance — every pick, every result, every point. Wins are highlighted in gold. Missed picks cost you points, so don't forget!",
+    },
+    onHighlightStarted: () => expandWidget("#widget-pick-history"),
+  },
+  {
+    element: "#widget-league-picks",
+    popover: {
+      title: "League Picks",
+      description: "See who everyone in your league picked this week. No duplicate restrictions — multiple people can pick the same golfer.",
+    },
+    onHighlightStarted: () => expandWidget("#widget-league-picks"),
+  },
+  {
+    popover: {
+      title: "That's the tour!",
+      description: "Go ahead and explore — make a pick, check the leaderboard. When you're ready, hit 'Sign Up Free' to create your own league.",
+    },
+  },
+];
+
+const DemoPage = () => {
+  const router = useRouter();
+  const { user, loading: authLoading } = useAuth();
+  const [demoLoading, setDemoLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [tourReady, setTourReady] = useState(false);
+
+  useEffect(() => {
+    const auth = getAuth(app);
+
+    const signInDemo = async () => {
+      try {
+        if (auth.currentUser?.email === DEMO_EMAIL) {
+          setDemoLoading(false);
+          return;
+        }
+
+        if (auth.currentUser) {
+          await signOut(auth);
+        }
+
+        await setPersistence(auth, browserSessionPersistence);
+        await signInWithEmailAndPassword(auth, DEMO_EMAIL, DEMO_PASSWORD);
+        setDemoLoading(false);
+      } catch (err) {
+        console.error("Demo sign-in failed:", err);
+        setError("Demo is temporarily unavailable. Please try again later.");
+        setDemoLoading(false);
+      }
+    };
+
+    if (!authLoading) {
+      signInDemo();
+    }
+  }, [authLoading]);
+
+  // Start the tour once widgets have had time to render
+  useEffect(() => {
+    if (!demoLoading && !authLoading && user && !tourReady) {
+      const timer = setTimeout(() => setTourReady(true), 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [demoLoading, authLoading, user, tourReady]);
+
+  useEffect(() => {
+    if (!tourReady) return;
+
+    const driverObj = driver({
+      showProgress: true,
+      animate: true,
+      allowClose: false,
+      allowKeyboardControl: true,
+      disableActiveInteraction: true,
+      overlayColor: "black",
+      overlayOpacity: 0.75,
+      stagePadding: 8,
+      stageRadius: 8,
+      popoverClass: "demo-tour-popover",
+      nextBtnText: "Next",
+      prevBtnText: "Back",
+      doneBtnText: "Let's go!",
+      showButtons: ["next", "previous", "close"],
+      steps: TOUR_STEPS,
+      onNextClick: () => {
+        const stepIndex = driverObj.getActiveIndex();
+
+        if (stepIndex === LEADERBOARD_STEP_INDEX) {
+          // Programmatically click the first name to open pick history modal
+          const name = document.querySelector("#widget-leaderboard span.cursor-pointer");
+          if (name) name.click();
+          // Wait for modal to open, then advance
+          setTimeout(() => driverObj.moveNext(), 200);
+          return;
+        }
+
+        if (stepIndex === MODAL_STEP_INDEX) {
+          // Close the modal before advancing
+          const closeBtn = document.querySelector("#pick-history-modal button[aria-label='Close dialog']");
+          if (closeBtn) closeBtn.click();
+          setTimeout(() => driverObj.moveNext(), 200);
+          return;
+        }
+
+        driverObj.moveNext();
+      },
+      onPrevClick: () => {
+        const stepIndex = driverObj.getActiveIndex();
+
+        if (stepIndex === MODAL_STEP_INDEX) {
+          // Close the modal before going back
+          const closeBtn = document.querySelector("#pick-history-modal button[aria-label='Close dialog']");
+          if (closeBtn) closeBtn.click();
+          setTimeout(() => driverObj.movePrevious(), 200);
+          return;
+        }
+
+        driverObj.movePrevious();
+      },
+    });
+
+    driverObj.drive();
+
+    return () => driverObj.destroy();
+  }, [tourReady]);
+
+  const handleExitDemo = async () => {
+    const auth = getAuth(app);
+    if (auth.currentUser?.email === DEMO_EMAIL) {
+      await signOut(auth);
+    }
+    router.push("/login");
+  };
+
+  if (demoLoading || authLoading) {
+    return <LoadingScreen />;
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-black flex flex-col items-center justify-center px-6">
+        <Logo logoSize={80} className="mb-6" />
+        <p className="text-white/70 text-lg mb-4">{error}</p>
+        <Link
+          href="/login"
+          className="text-[#BFFF00] hover:underline"
+        >
+          Back to login
+        </Link>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <LoadingScreen />;
+  }
+
+  return (
+    <>
+      {/* Demo Banner */}
+      <div className="bg-gradient-to-r from-[#BFFF00]/10 via-[#BFFF00]/20 to-[#BFFF00]/10 border-b border-[#BFFF00]/20 relative z-50">
+        <div className="max-w-[1200px] mx-auto px-4 py-2 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-3">
+            <div className="w-2 h-2 rounded-full bg-[#BFFF00] animate-pulse flex-shrink-0" />
+            <p className="text-white/80 text-sm">
+              <span className="font-semibold text-[#BFFF00]">Demo Mode</span>
+              <span className="hidden sm:inline">
+                {" "}&mdash; explore the dashboard, make real picks
+              </span>
+            </p>
+          </div>
+          <div className="flex items-center gap-3 flex-shrink-0">
+            <button
+              onClick={handleExitDemo}
+              className="text-white/50 hover:text-white text-sm transition-colors"
+            >
+              Exit Demo
+            </button>
+            <Link
+              href="/signup"
+              onClick={handleExitDemo}
+              className="px-4 py-1.5 rounded-lg bg-[#BFFF00] text-black font-semibold text-sm hover:bg-[#9FDF00] transition-colors"
+            >
+              Sign Up Free
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Real dashboard */}
+      <PageLayout disableSidebar />
+    </>
+  );
+};
+
+export default DemoPage;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,3 +5,66 @@
 .font-verdana{
   font-family: Verdana, Geneva, Tahoma, sans-serif;
 }
+
+@keyframes rainbow-shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(200%); }
+}
+
+/* driver.js dark theme overrides */
+.demo-tour-popover.driver-popover {
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+.demo-tour-popover .driver-popover-title {
+  color: #BFFF00;
+  font-size: 1.1rem;
+}
+
+.demo-tour-popover .driver-popover-description {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.demo-tour-popover .driver-popover-progress-text {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.demo-tour-popover .driver-popover-next-btn,
+.demo-tour-popover .driver-popover-close-btn {
+  background: #BFFF00;
+  color: black;
+  border: none;
+  font-weight: 600;
+  text-shadow: none;
+}
+
+.demo-tour-popover .driver-popover-next-btn:hover,
+.demo-tour-popover .driver-popover-close-btn:hover {
+  background: #9FDF00;
+}
+
+.demo-tour-popover .driver-popover-prev-btn {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.demo-tour-popover .driver-popover-prev-btn:hover {
+  color: white;
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.demo-tour-popover .driver-popover-arrow-side-left .driver-popover-arrow,
+.demo-tour-popover .driver-popover-arrow-side-right .driver-popover-arrow,
+.demo-tour-popover .driver-popover-arrow-side-top .driver-popover-arrow,
+.demo-tour-popover .driver-popover-arrow-side-bottom .driver-popover-arrow {
+  border-color: #1a1a1a;
+}
+
+/* Ensure pick history modal renders above driver.js overlay when highlighted */
+#pick-history-modal {
+  z-index: 100002 !important;
+}

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import Link from "next/link";
 import LogInForm from "../components/forms/log-in";
 import HeroContainer from '../components/hero-container';
 import FloatingText from "../components/floating-text";
@@ -24,16 +25,34 @@ const LoginPage = () => {
   return (
     <div className="min-h-screen bg-black flex flex-col items-center justify-top px-6 pb-[env(safe-area-inset-bottom,24px)]">
       <div className="w-full max-w-[1000px]">
-        <div className="flex flex-row items-center mt-10">
-          <Logo className="mb-4 z-10" logoSize={100} />
-          <div className="flex flex-col mb-4">
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold leading-[0.9] tracking-tighter bg-gradient-to-t from-gray-400 to-white bg-clip-text text-transparent pb-2 md:pb-3 lg:pb-4">
-              pick.golf<span className="text-sm text-gray-500 tracking-tight">(beta)</span>
-            </h1>
+        <div className="flex flex-row items-center justify-between mt-10">
+          <div className="flex flex-row items-center">
+            <Logo className="mb-4 z-10" logoSize={100} />
+            <div className="flex flex-col mb-4">
+              <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold leading-[0.9] tracking-tighter bg-gradient-to-t from-gray-400 to-white bg-clip-text text-transparent pb-2 md:pb-3 lg:pb-4">
+                pick.golf
+              </h1>
+            </div>
           </div>
+          <Link
+            href="/demo"
+            className="mb-4 px-5 py-2 rounded-xl border border-white/20 bg-white/5 backdrop-blur-sm hover:bg-white/10 hover:border-[#BFFF00]/40 transition-all duration-300 group relative overflow-hidden"
+          >
+            <span
+              className="absolute inset-0 w-1/2"
+              style={{
+                background: "linear-gradient(90deg, transparent, rgba(255,0,0,0.08), rgba(255,165,0,0.08), rgba(255,255,0,0.08), rgba(0,255,0,0.08), rgba(0,150,255,0.08), rgba(128,0,255,0.08), transparent)",
+                animation: "rainbow-shimmer 3s ease-in-out infinite",
+              }}
+            />
+            <span className="relative text-white/70 group-hover:text-white text-sm font-medium transition-colors">
+              Try the demo
+            </span>
+            <span className="relative ml-2 text-white/40 group-hover:text-[#BFFF00] transition-colors">&rarr;</span>
+          </Link>
         </div>
       </div>
-      
+
       <HeroContainer>
         <div className="flex flex-col items-center w-full gap-4">
           <FloatingText>
@@ -49,7 +68,7 @@ const LoginPage = () => {
       </HeroContainer>
 
       <p className="text-gray-300 mt-8 mb-8 text-sm italic">
-        Need help? Email jmonahan@pgatour.com
+        Need help? Email help@ailette.io
       </p>
     </div>
   );

--- a/src/app/signup/page.js
+++ b/src/app/signup/page.js
@@ -7,7 +7,7 @@ const SignUpPage = () => {
     <div className="min-h-screen bg-black flex flex-col items-center justify-center px-6">
       <div className="w-full max-w-[1000px] flex flex-col mb-4">
         <h1 className="text-7xl font-bold leading-[0.9] mt-6 tracking-tighter bg-gradient-to-t from-gray-400 to-white bg-clip-text text-transparent pb-2">
-          pick.golf<span className="text-lg text-gray-500 tracking-tight">(beta)</span>
+          pick.golf
         </h1>
       </div>
 
@@ -16,7 +16,7 @@ const SignUpPage = () => {
       </div>
 
       <p className="text-gray-500 mt-8 text-sm">
-        Need help? Email jmonahan@pgatour.com
+        Need help? Email help@ailette.io
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds public demo page at `/demo` that auto-signs in as `ailettedemo@gmail.com` via Firebase email/password auth with session-only persistence
- Uses all real dashboard widgets (Pick, Leaderboard, Pick History, League Picks) — zero mock data, zero backend changes
- Guided onboarding tour via driver.js that walks prospective users through each widget, including programmatic pick history modal demo
- Demo user is gatekept from `/dashboard` and other protected routes via `GuardedPage`
- Sidebar disabled in demo mode, background interactions blocked during tour
- Mobile-aware: collapses other widgets when tour highlights one on small screens
- "Try the demo" button with rainbow shimmer on login page
- Removed `(beta)` tag from login/signup, updated help email to `help@ailette.io`, removed legacy form from sidebar

## QA Checklist
- [ ] Login page renders with "Try the demo" button (rainbow shimmer)
- [ ] `/demo` auto-signs in and shows real dashboard with demo banner
- [ ] Tour walks through all widgets (welcome → pick → leaderboard → modal → history → league picks → outro)
- [ ] Tour expands collapsed widgets before highlighting
- [ ] Tour programmatically opens pick history modal on leaderboard step
- [ ] Background clicks disabled during tour
- [ ] Demo user cannot access `/dashboard` (redirected to `/demo`)
- [ ] "Exit Demo" signs out and returns to login
- [ ] Tab close kills demo session (session-only persistence)
- [ ] Signup page shows no `(beta)` tag, help email is `help@ailette.io`
- [ ] Sidebar has no "Legacy Form" link

## Prerequisites
- `ailettedemo@gmail.com` Firebase user exists with password set
- Demo user exists in backend database
- Demo user is member of a demo league
- `NEXT_PUBLIC_DEMO_PASSWORD` env var set in Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)